### PR TITLE
[WIP] ja: use docs api server rendering home page.

### DIFF
--- a/partials/home/backers.vue
+++ b/partials/home/backers.vue
@@ -1,9 +1,8 @@
 <template>
   <section class="nBackers">
     <div class="container">
-      <h2 class="nBackers_Title"><span>Support the Team</span></h2>
-      <p class="nBackers_Description">
-        Nuxt.js is an MIT licensed open source project and completely free to use. However, the amount of effort needed to maintain and develop new features for the project is not sustainable without proper financial backing. Your donations directly support office hours, continued enhancements, and most importantly, great documentation and learning material.
+      <h2 class="nBackers_Title"><span>{{ $store.state.homepage.backers.attrs.title }}</span></h2>
+      <p class="nBackers_Description" v-html="$store.state.homepage.backers.body">
       </p>
       <div class="nBackers_Group">
         <h3 class="nBackers_Group_Title">Partners</h3>

--- a/partials/home/modes.vue
+++ b/partials/home/modes.vue
@@ -1,44 +1,27 @@
 <template>
   <section class="nModes">
     <div class="container">
-      <h2 class="nModes_Title"><span>Rendering modes</span></h2>
+      <h2 class="nModes_Title"><span>{{ $store.state.homepage.modes.attrs.title }}</span></h2>
       <div class="row">
         <ul class="nModes_Tabs">
-          <li class="nModes_Tabs_Option" :class="{'nModes_Tabs_Option--selected-first': mode === 0}" @click="mode = 0">Server Side Rendered</li>
-          <li class="nModes_Tabs_Option" :class="{'nModes_Tabs_Option--selected': mode === 1}" @click="mode = 1">Statically Generated</li>
-          <li class="nModes_Tabs_Option" :class="{'nModes_Tabs_Option--selected-last': mode === 2}" @click="mode = 2">Single Page App</li>
+          <li class="nModes_Tabs_Option" :class="{'nModes_Tabs_Option--selected-first': mode === 0}" @click="mode = 0">{{ $store.state.homepage.modes_server_side_rendering.attrs.title }}</li>
+          <li class="nModes_Tabs_Option" :class="{'nModes_Tabs_Option--selected': mode === 1}" @click="mode = 1">{{ $store.state.homepage.modes_statically_generated.attrs.title }}</li>
+          <li class="nModes_Tabs_Option" :class="{'nModes_Tabs_Option--selected-last': mode === 2}" @click="mode = 2">{{ $store.state.homepage.modes_single_page_app.attrs.title }}</li>
         </ul>
         <div class="nModes_Content">
           <div v-show="mode === 0">
-            <h3 class="nModes_Content_Title">Server Side Rendered (Universal)</h3>
-            <p class="nModes_Content_Description">
-              The most popular mode for Nuxt. With SSR, also called "universal" or "isomorphic" mode, a Node.js server
-              will be used to deliver HTML based on your Vue components to the client instead of the pure javascript.
-              Using SSR will lead to a large SEO boost, better UX and more opportunities (compared to a traditional Vue SPA).
-              <br><br>
-              Because implementing SSR on your own can be really tedious, Nuxt.js gives you full support out of the box
-              and will take care of common pitfalls.
+            <h3 class="nModes_Content_Title">{{ $store.state.homepage.modes_server_side_rendering.attrs.content_title }}</h3>
+            <p class="nModes_Content_Description" v-html="$store.state.homepage.modes_server_side_rendering.body">
             </p>
           </div>
           <div v-show="mode === 1">
-            <h3 class="nModes_Content_Title">Statically Generated (Pre-Rendering)</h3>
-            <p class="nModes_Content_Description">
-              Static Site Generation is a very hot topic right now! Instead of switching to another framework and
-              spending time to get used to it, why not killing two birds with one stone?
-              <span style="color: #777">(only proverbial 🐦🐦)</span><br><br>
-              Nuxt.js supports generating a static website based on your Vue application. It is the "best of both worlds"
-              as you don't need a server but still have SEO benefits because Nuxt will pre-render all pages and include
-              the necessary HTML. Also, you can deploy the resulting page easily to Netlify or GitHub pages.
+            <h3 class="nModes_Content_Title">{{ $store.state.homepage.modes_statically_generated.attrs.content_title }}</h3>
+            <p class="nModes_Content_Description" v-html="$store.state.homepage.modes_statically_generated.body">
             </p>
           </div>
           <div v-show="mode === 2">
-            <h3 class="nModes_Content_Title">Single Page Application (SPA)</h3>
-            <p class="nModes_Content_Description">
-              Don't need SSR or Static Site Generation but still want to profit from the benefits that Nuxt provides?
-              Are you slowly transitioning your app and want to start lightweight? Then the traditional SPA mode will
-              likely be your choice.
-              The outcome will be a typical Vue SPA as you know it but influenced by your Nuxt configuration and the
-              framework itself.
+            <h3 class="nModes_Content_Title">{{ $store.state.homepage.modes_single_page_app.attrs.content_title }}</h3>
+            <p class="nModes_Content_Description" v-html="$store.state.homepage.modes_single_page_app.body">
             </p>
           </div>
         </div>

--- a/partials/home/welcome.vue
+++ b/partials/home/welcome.vue
@@ -3,15 +3,13 @@
     <div class="container">
       <div class="row">
         <div class="nWelcome_Content">
-          <h1 class="nWelcome_Content_Title">
-            The <span class="nWelcome_Content_Title_Primary">Vue.js</span> Framework
-          <!-- {{ $store.state.lang.homepage.title }} -->
+          <h1 class="nWelcome_Content_Title" v-html="$store.state.homepage.welcome.attrs.title">
+            <!-- {{ $store.state.lang.homepage.title }} -->
           </h1>
           <h4 class="nWelcome_Content_Subtitle">
             For <transition name="fade" mode="out-in"><span class="nWelcome_Content_Subtitle_Type" v-for="(appType, index) of appTypes" :key="appType" v-if="index === current">{{ appType }}</span></transition>.
           </h4>
-          <p class="nWelcome_Content_Description">
-            Nuxt.js presets all the configuration needed to make your development of a Vue.js application enjoyable.
+          <p class="nWelcome_Content_Description" v-html="$store.state.homepage.welcome.body">
           </p>
           <div class="nWelcome_Content_Links">
             <nuxt-link class="nWelcome_Content_Links_Button nWelcome_Content_Links_Button--green" to="/guide/installation">
@@ -24,7 +22,7 @@
         </div>
         <figure class="nWelcome_Figure">
           <responsive-video src="https://player.vimeo.com/video/311756540" style="margin: 0;"/>
-          <p>Video produced by <a href="https://www.vuemastery.com" target="_blank" rel="noopener">Vue Mastery</a>, download their free <a href="https://www.vuemastery.com/nuxt-cheat-sheet/" target="_blank" rel="noopener">Nuxt Cheat Sheet</a>.</p>
+          <p v-html="$store.state.homepage.welcome_figure.body"></p>
         </figure>
       </div>
     </div>

--- a/partials/home/why.vue
+++ b/partials/home/why.vue
@@ -1,35 +1,24 @@
 <template>
   <section class="nWhy">
     <div class="container">
-      <h2 class="nWhy_Title"><span>Why Nuxt?</span></h2>
+      <h2 class="nWhy_Title"><span>{{ $store.state.homepage.why.attrs.title }}</span></h2>
       <div class="row">
         <div class="nWhy_Block">
           <i-performant/>
-          <h4 class="nWhy_Block_Title">Performant</h4>
-          <p class="nWhy_Block_Description">
-            With Nuxt.js, your application will be optimized out of the box.
-            We do our best to build performant applications by utilizing Vue.js and Node.js best practices.
-            To squeeze every unnecessary bit out of your app Nuxt includes a bundle analyzer and lots of opportunities
-            to fine-tune your app.
+          <h4 class="nWhy_Block_Title">{{ $store.state.homepage.why_performant.attrs.title }}</h4>
+          <p class="nWhy_Block_Description" v-html="$store.state.homepage.why_performant.body">
           </p>
         </div>
         <div class="nWhy_Block">
           <i-modular/>
-          <h4 class="nWhy_Block_Title">Modular</h4>
-          <p class="nWhy_Block_Description">
-            Nuxt is based on a powerful modular architecture. You can choose from more than 50 modules to make your
-            development faster and easier. You don't have to reinvent the wheel to get PWA benefits, add Google Analytics
-            to your page or generate a sitemap.
+          <h4 class="nWhy_Block_Title">{{ $store.state.homepage.why_modular.attrs.title }}</h4>
+          <p class="nWhy_Block_Description" v-html="$store.state.homepage.why_modular.body">
           </p>
         </div>
         <div class="nWhy_Block">
           <i-enjoyable/>
-          <h4 class="nWhy_Block_Title">Enjoyable</h4>
-          <p class="nWhy_Block_Description">
-            Our main focus is the Developer Experience. We love Nuxt.js and continuously improve the framework
-            so you love it too! 💚<br>
-            Expect appealing solutions, descriptive error messages, powerful defaults and a detailed
-            documentation. If questions or problems come up, our helpful community will help you out.
+          <h4 class="nWhy_Block_Title">{{ $store.state.homepage.why_enjoyable.attrs.title }}</h4>
+          <p class="nWhy_Block_Description" v-html="$store.state.homepage.why_enjoyable.body">
           </p>
         </div>
       </div>

--- a/plugins/init.js
+++ b/plugins/init.js
@@ -31,6 +31,8 @@ export default async function ({ isDev, env, req, store: { commit, state }, redi
     commit('setDocVersion', resLang.data.docVersion)
     const resMenu = await axios(state.apiURI + '/menu/' + state.locale)
     commit('setMenu', resMenu.data)
+    const resHomepage = await axios(state.apiURI + '/homepage/' + state.locale)
+    commit('setHomepage', resHomepage.data)
     commit('setFilled')
   } catch (e) {
     console.error('Error on filling the store, please run the docs server.') // eslint-disable-line no-console

--- a/store/index.js
+++ b/store/index.js
@@ -10,6 +10,7 @@ export const state = () => ({
   locale: 'en',
   lang: {},
   menu: {},
+  homepage: {},
   adBlocked: false
 })
 
@@ -34,6 +35,9 @@ export const mutations = {
   },
   setMenu(state, menu) {
     state.menu = menu
+  },
+  setHomepage(state, homepage) {
+    state.homepage = homepage
   },
   setFilled(state) {
     state.filled = true


### PR DESCRIPTION
See also: [need link](need link)

The nuxtjs.org homepage(top page) contents are written in source code directly. To translate it, we need to move these contents to the language resources and docs contents files.

In this pull request, I'd move contents data to [/nuxt/docs] repository and call `docs.api.nuxt.org/homepage/(lang)` to fetch it.

I'm sending pull request about language resource file here: [need link](need link).

This pull request includes:
- Add homepage data to the state store
- Call docs api servers `/homepage/*(lang)` and store it
- Use store data, `$store.state.homepage`, to display contents
  - It is the same format as other documents. But, "Rendering modes" files contain `content_title` for reproducing the original display
- Move the homepage contents to [/nuxt/docs] repository

I need feedback and improvement:
- I'd respect original contents and markup, but any assumption is there?